### PR TITLE
Implement basic functionality to install different ruby versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "clamp"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "https://rubygems.org"
 
 gem "clamp"
+
+group :test do
+  gem "minitest-stub-const"
+  gem "pry"
+end

--- a/lib/orr.rb
+++ b/lib/orr.rb
@@ -1,0 +1,6 @@
+require 'clamp'
+require 'rbconfig'
+require "rexml/document"
+
+require_relative 'shell_command'
+require_relative 'orr_command'

--- a/lib/orr.rb
+++ b/lib/orr.rb
@@ -1,6 +1,7 @@
 require 'clamp'
 require 'rbconfig'
 require "rexml/document"
+require "pathname"
 
 require_relative 'shell_command'
 require_relative 'orr_command'

--- a/lib/orr_command.rb
+++ b/lib/orr_command.rb
@@ -1,0 +1,5 @@
+class OrrCommand < Clamp::Command
+  def shell_command
+    ShellCommand.new
+  end
+end

--- a/lib/shell_command.rb
+++ b/lib/shell_command.rb
@@ -2,4 +2,8 @@ class ShellCommand
   def run(command_line)
     `#{command_line}`.chomp
   end
+
+  def run_interactive(command_line)
+    system(command_line)
+  end
 end

--- a/lib/shell_command.rb
+++ b/lib/shell_command.rb
@@ -1,0 +1,5 @@
+class ShellCommand
+  def run(command_line)
+    `#{command_line}`.chomp
+  end
+end

--- a/orr
+++ b/orr
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
-require 'clamp'
-require 'rbconfig'
+require_relative 'lib/orr'
 Dir[File.join(File.dirname(__FILE__), 'plugins', '*.rb')].each {|file| require file } 
 
 Clamp do

--- a/plugins/do.rb
+++ b/plugins/do.rb
@@ -1,4 +1,4 @@
-class OrrDoCommand < Clamp::Command
+class OrrDoCommand < OrrCommand
   def execute
     puts "do"
   end

--- a/plugins/implode.rb
+++ b/plugins/implode.rb
@@ -1,4 +1,4 @@
-class OrrImplodeCommand < Clamp::Command
+class OrrImplodeCommand < OrrCommand
   def execute
     puts "implode"
   end

--- a/plugins/info.rb
+++ b/plugins/info.rb
@@ -41,6 +41,7 @@ system:
 EOT
     puts orr_info
   end
+
   def get_bash_info
     @bash_path = `which bash`.gsub("\n", '')
     @bash_version = `bash --version|head -n1`.gsub("\n", '') if !@bash_path.empty?

--- a/plugins/info.rb
+++ b/plugins/info.rb
@@ -1,6 +1,4 @@
-require_relative "../lib/shell_command"
-
-class OrrInfoCommand < Clamp::Command
+class OrrInfoCommand < OrrCommand
   def execute
     uname_output = `uname -a`.gsub("\n", '')
     get_bash_info
@@ -52,9 +50,5 @@ EOT
 
   def get_executable(command)
     shell_command.run("which #{command}")
-  end
-
-  def shell_command
-    ShellCommand.new
   end
 end

--- a/plugins/info.rb
+++ b/plugins/info.rb
@@ -8,20 +8,8 @@ system:
 
   system:
     uname:        "#{uname_output}"
-    name:         "openSUSE"
-    version:      "42.2"
     architecture: "#{RbConfig::CONFIG['target_cpu']}"
     bash:         "#{@bash_path} => #{@bash_version}"
-    zsh:          "#{@zsh_path} => #{@zsh_version}"
-
-  orr:
-    version:      "0.1"
-    path:         "/home/vagrant/.rvm"
-    autolibs:     "[4] Allow RVM to use package manager if found, install missing dependencies, install package manager (only OS X)."
-
-  homes:
-    gem:          "not set"
-    ruby:         "not set"
 
   binaries:
     ruby:         "#{get_executable("ruby")}"
@@ -30,13 +18,8 @@ system:
     rake:         "#{get_executable("rake")}"
 
   environment:
-    PATH:         "/home/vagrant/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/vagrant/.rvm/bin"
-    GEM_HOME:     ""
-    GEM_PATH:     ""
-    MY_RUBY_HOME: ""
-    IRBRC:        ""
-    RUBYOPT:      ""
-    gemset:       ""
+    PATH:         "#{ENV['PATH']}"
+    GEM_HOME:     "#{ENV['GEM_HOME']}"
 
 EOT
     puts orr_info

--- a/plugins/info.rb
+++ b/plugins/info.rb
@@ -1,3 +1,5 @@
+require_relative "../lib/shell_command"
+
 class OrrInfoCommand < Clamp::Command
   def execute
     uname_output = `uname -a`.gsub("\n", '')
@@ -24,10 +26,10 @@ system:
     ruby:         "not set"
 
   binaries:
-    ruby:         "/usr/bin/ruby"
-    irb:          "/usr/bin/irb"
-    gem:          "/usr/bin/gem"
-    rake:         "/usr/bin/rake"
+    ruby:         "#{get_executable("ruby")}"
+    irb:          "#{get_executable("irb")}"
+    gem:          "#{get_executable("gem")}"
+    rake:         "#{get_executable("rake")}"
 
   environment:
     PATH:         "/home/vagrant/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/home/vagrant/.rvm/bin"
@@ -46,5 +48,13 @@ EOT
     @bash_path = `which bash`.gsub("\n", '')
     @bash_version = `bash --version|head -n1`.gsub("\n", '') if !@bash_path.empty?
     @bash_version = "not installed" if @bash_path.empty?
+  end
+
+  def get_executable(command)
+    shell_command.run("which #{command}")
+  end
+
+  def shell_command
+    ShellCommand.new
   end
 end

--- a/plugins/install.rb
+++ b/plugins/install.rb
@@ -1,5 +1,7 @@
 class OrrInstallCommand < Clamp::Command
+  parameter "VERSION ...", "Ruby version", :attribute_name => :ruby_version
+
   def execute
-    puts "install"
+    puts "Installing ruby#{ruby_version.first}"
   end
 end

--- a/plugins/install.rb
+++ b/plugins/install.rb
@@ -1,7 +1,80 @@
-class OrrInstallCommand < Clamp::Command
-  parameter "VERSION ...", "Ruby version", :attribute_name => :ruby_version
+class OrrInstallCommand < OrrCommand
+  parameter "VERSION ...", "Ruby version", :attribute_name => :ruby_version_arg
+
+  def home_dir
+    Pathname(ENV["HOME"])
+  end
 
   def execute
-    puts "Installing ruby#{ruby_version.first}"
+    ruby_version = ruby_version_arg.first
+    bin_dir = home_dir + "bin"
+
+    puts "Installing ruby#{ruby_version} in #{bin_dir}"
+
+    shell_command.run_interactive("sudo zypper in ruby#{ruby_version}")
+
+    ["ruby", "irb", "gem", "rake"].each do |cmd|
+      if File.exist?(bin_dir + cmd)
+        File.delete(bin_dir + cmd)
+      end
+      File.symlink("/usr/bin/#{cmd}.ruby#{ruby_version}", bin_dir + cmd)
+    end
+
+    edit_bashrc(ruby_version)
+    edit_gemrc
+
+    puts "Make sure to restart your shell to make new GEM_HOME and PATH settings active"
+  end
+
+  def edit_bashrc(ruby_version)
+    bashrc = home_dir + ".bashrc"
+
+    export_gem_home = "export GEM_HOME=~/.gems/ruby#{ruby_version}\n"
+    export_path = "export PATH=$GEM_HOME/bin:$PATH\n"
+
+    bashrc_out = ""
+    found_home = false
+    found_path = false
+    bashrc.each_line do |line|
+      if line =~ /^export GEM_HOME=/
+        bashrc_out += export_gem_home
+        found_home = true
+      elsif line =~ /^export PATH=\$GEM_HOME\/bin:\$PATH/
+        bashrc_out += line
+        found_path = true
+      else
+        bashrc_out += line
+      end
+    end
+    if !found_home
+      bashrc_out += export_gem_home
+    end
+    if !found_path
+      bashrc_out += export_path
+    end
+
+    File.write(bashrc, bashrc_out)
+  end
+
+  def edit_gemrc
+    gemrc = home_dir + ".gemrc"
+
+    install_setting = "install: --no-format-executable"
+
+    gemrc_out = ""
+    found_install_setting = false
+    if File.exist?(gemrc)
+      gemrc.each_line do |line|
+        if line.chomp == install_setting
+          found_install_setting = true
+        end
+        gemrc_out += line
+      end
+    end
+    if !found_install_setting
+      gemrc_out += install_setting + "\n"
+    end
+
+    File.write(gemrc, gemrc_out)
   end
 end

--- a/plugins/list.rb
+++ b/plugins/list.rb
@@ -1,4 +1,4 @@
-class OrrListCommand < Clamp::Command
+class OrrListCommand < OrrCommand
   def execute
     puts "Installed ruby versions:"
     rpms = shell_command.run("rpm -qa")
@@ -20,9 +20,5 @@ class OrrListCommand < Clamp::Command
     ruby_name = $1
     ruby_version = shell_command.run("ruby -v")
     puts "* #{ruby_name} (path: #{ruby_path}, version: #{ruby_version})"
-  end
-
-  def shell_command
-    ShellCommand.new
   end
 end

--- a/plugins/list.rb
+++ b/plugins/list.rb
@@ -1,5 +1,28 @@
 class OrrListCommand < Clamp::Command
   def execute
-    puts "list"
+    puts "Installed ruby versions:"
+    rpms = shell_command.run("rpm -qa")
+    rubies = []
+    rpms.each_line do |rpm|
+      if rpm =~ /^(ruby\d.\d+)-\d/
+        rubies.push $1
+      end
+    end
+    rubies.sort.each do |ruby|
+      puts "* #{ruby}"
+    end
+    puts
+
+    puts "Active ruby:"
+    ruby_path = shell_command.run("which ruby")
+    ruby_rpm = shell_command.run("rpm -qf #{ruby_path}")
+    ruby_rpm =~ /^(ruby\d\.\d+)-/
+    ruby_name = $1
+    ruby_version = shell_command.run("ruby -v")
+    puts "* #{ruby_name} (path: #{ruby_path}, version: #{ruby_version})"
+  end
+
+  def shell_command
+    ShellCommand.new
   end
 end

--- a/plugins/reinstall.rb
+++ b/plugins/reinstall.rb
@@ -1,4 +1,4 @@
-class OrrReinstallCommand < Clamp::Command
+class OrrReinstallCommand < OrrCommand
   def execute
     puts "reinstall"
   end

--- a/plugins/remove.rb
+++ b/plugins/remove.rb
@@ -1,4 +1,4 @@
-class OrrRemoveCommand < Clamp::Command
+class OrrRemoveCommand < OrrCommand
   def execute
     puts "remove"
   end

--- a/plugins/reset.rb
+++ b/plugins/reset.rb
@@ -1,4 +1,4 @@
-class OrrResetCommand < Clamp::Command
+class OrrResetCommand < OrrCommand
   def execute
     puts "reset"
   end

--- a/plugins/search.rb
+++ b/plugins/search.rb
@@ -1,7 +1,4 @@
-require_relative "../lib/shell_command"
-require "rexml/document"
-
-class OrrSearchCommand < Clamp::Command
+class OrrSearchCommand < OrrCommand
   def execute
     rubies = []
 
@@ -19,9 +16,5 @@ class OrrSearchCommand < Clamp::Command
     end
 
     puts rubies.join("\n")
-  end
-
-  def shell_command
-    ShellCommand.new
   end
 end

--- a/plugins/search.rb
+++ b/plugins/search.rb
@@ -1,5 +1,27 @@
+require_relative "../lib/shell_command"
+require "rexml/document"
+
 class OrrSearchCommand < Clamp::Command
   def execute
-    puts "search"
+    rubies = []
+
+    xml = shell_command.run("zypper --xml se 'ruby*'")
+    doc = REXML::Document.new(xml)
+    doc.elements.each("stream/search-result/solvable-list/solvable") do |element|
+      name = element.attributes["name"]
+      status = element.attributes["status"]
+      kind = element.attributes["kind"]
+      if name =~ /^ruby\d\.\d+$/ && kind == "package"
+        ruby = name
+        ruby += " (installed)" if status == "installed"
+        rubies.push(ruby)
+      end
+    end
+
+    puts rubies.join("\n")
+  end
+
+  def shell_command
+    ShellCommand.new
   end
 end

--- a/plugins/uninstall.rb
+++ b/plugins/uninstall.rb
@@ -1,4 +1,4 @@
-class OrrUninstallCommand < Clamp::Command
+class OrrUninstallCommand < OrrCommand
   def execute
     puts "uninstall"
   end

--- a/plugins/upgrade.rb
+++ b/plugins/upgrade.rb
@@ -1,4 +1,4 @@
-class OrrUpgradeCommand < Clamp::Command
+class OrrUpgradeCommand < OrrCommand
   def execute
     puts "upgrade"
   end

--- a/plugins/use.rb
+++ b/plugins/use.rb
@@ -1,4 +1,4 @@
-class OrrUseCommand < Clamp::Command
+class OrrUseCommand < OrrCommand
   def execute
     puts "use"
   end

--- a/spec/info_spec.rb
+++ b/spec/info_spec.rb
@@ -3,12 +3,16 @@ require_relative '../plugins/' + File.basename(__FILE__, '_spec.rb')
 
 describe OrrInfoCommand do
   before do
-    @info = OrrInfoCommand.new
+    invocation_path = ""
+    @info = OrrInfoCommand.new(invocation_path)
   end
 
   describe "when executed" do
     it "must respond" do
-      @info.run.must_equal "OHAI!"
+      arguments = []
+      assert_output(/system:/) {
+        @info.run(arguments)
+      }
     end
   end
 

--- a/spec/info_spec.rb
+++ b/spec/info_spec.rb
@@ -14,6 +14,19 @@ describe OrrInfoCommand do
         @info.run(arguments)
       }
     end
-  end
 
+    it "returns ruby path" do
+      mock = Minitest::Mock.new
+      mock.expect :run, "/path/to/ruby", ["which ruby"]
+      mock.expect :run, "/path/to/irb", ["which irb"]
+      mock.expect :run, "/path/to/gem", ["which gem"]
+      mock.expect :run, "/path/to/rake", ["which rake"]
+      @info.stub :shell_command, mock do
+        arguments = []
+        assert_output(/ruby:\s*"\/path\/to\/ruby/) {
+          @info.run(arguments)
+        }
+      end
+    end
+  end
 end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -7,12 +7,107 @@ describe OrrInstallCommand do
     @cmd = OrrInstallCommand.new(invocation_path)
   end
 
-  describe "when executed" do
+  describe "when ruby version is not installed yet" do
     it "installs given ruby version" do
       arguments = ["2.3"]
-      assert_output("Installing ruby2.3\n") {
-        @cmd.run(arguments)
-      }
+      Dir.mktmpdir("orr-test") do |home_dir|
+        bin_dir = Pathname.new(home_dir) + "bin"
+        Dir.mkdir(bin_dir)
+
+        bashrc = Pathname.new(home_dir) + ".bashrc"
+        bashrc_content = <<EOT
+# This is an exemplary .bashrc
+PS1='something'
+EOT
+        File.write(bashrc, bashrc_content)
+
+        env = ENV.to_hash.merge("HOME" => home_dir)
+
+        mock = Minitest::Mock.new
+        mock.expect :run_interactive, nil, ["sudo zypper in ruby2.3"]
+
+        @cmd.stub :shell_command, mock do
+          assert_output(/^Installing ruby2.3 in #{bin_dir}\n/) do
+            Object.stub_const(:ENV, env) do
+              @cmd.run(arguments)
+            end
+          end
+        end
+        assert_equal("/usr/bin/ruby.ruby2.3", File.readlink(bin_dir + "ruby"))
+        assert_equal("/usr/bin/irb.ruby2.3", File.readlink(bin_dir + "irb"))
+        assert_equal("/usr/bin/gem.ruby2.3", File.readlink(bin_dir + "gem"))
+        assert_equal("/usr/bin/rake.ruby2.3", File.readlink(bin_dir + "rake"))
+
+        expected_bashrc_content = bashrc_content + <<EOT
+export GEM_HOME=~/.gems/ruby2.3
+export PATH=$GEM_HOME/bin:$PATH
+EOT
+        assert_equal(expected_bashrc_content, File.read(bashrc))
+
+        expected_gemrc_content = <<EOT
+install: --no-format-executable
+EOT
+        assert_equal(expected_gemrc_content, File.read(Pathname.new(home_dir) + ".gemrc"))
+      end
+    end
+  end
+
+  describe "when ruby version is already installed" do
+    it "installs given ruby version" do
+      arguments = ["2.3"]
+      Dir.mktmpdir("orr-test") do |home_dir|
+        bin_dir = Pathname.new(home_dir) + "bin"
+        Dir.mkdir(bin_dir)
+        ["ruby", "irb", "gem", "rake"].each do |cmd|
+          File.symlink("/usr/bin/#{cmd}.ruby2.2", bin_dir + cmd)
+        end
+
+        bashrc = Pathname.new(home_dir) + ".bashrc"
+        bashrc_content = <<EOT
+# This is an exemplary .bashrc
+PS1='something'
+export GEM_HOME=~/.gems/ruby2.2
+export PATH=$GEM_HOME/bin:$PATH
+# something else
+EOT
+        File.write(bashrc, bashrc_content)
+
+        gemrc_content = <<EOT
+install: --no-format-executable
+EOT
+        File.write(Pathname(home_dir) + ".gemrc", gemrc_content)
+
+        env = ENV.to_hash.merge("HOME" => home_dir)
+
+        mock = Minitest::Mock.new
+        mock.expect :run_interactive, nil, ["sudo zypper in ruby2.3"]
+
+        @cmd.stub :shell_command, mock do
+          assert_output(/^Installing ruby2.3 in #{bin_dir}\n/) do
+            Object.stub_const(:ENV, env) do
+              @cmd.run(arguments)
+            end
+          end
+        end
+        assert_equal("/usr/bin/ruby.ruby2.3", File.readlink(bin_dir + "ruby"))
+        assert_equal("/usr/bin/irb.ruby2.3", File.readlink(bin_dir + "irb"))
+        assert_equal("/usr/bin/gem.ruby2.3", File.readlink(bin_dir + "gem"))
+        assert_equal("/usr/bin/rake.ruby2.3", File.readlink(bin_dir + "rake"))
+
+        expected_bashrc_content = <<EOT
+# This is an exemplary .bashrc
+PS1='something'
+export GEM_HOME=~/.gems/ruby2.3
+export PATH=$GEM_HOME/bin:$PATH
+# something else
+EOT
+        assert_equal(expected_bashrc_content, File.read(bashrc))
+
+        expected_gemrc_content = <<EOT
+install: --no-format-executable
+EOT
+        assert_equal(expected_gemrc_content, File.read(Pathname.new(home_dir) + ".gemrc"))
+      end
     end
   end
 end

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -1,0 +1,18 @@
+require_relative 'test_helper'
+require_relative '../plugins/' + File.basename(__FILE__, '_spec.rb')
+
+describe OrrInstallCommand do
+  before do
+    invocation_path = ""
+    @cmd = OrrInstallCommand.new(invocation_path)
+  end
+
+  describe "when executed" do
+    it "installs given ruby version" do
+      arguments = ["2.3"]
+      assert_output("Installing ruby2.3\n") {
+        @cmd.run(arguments)
+      }
+    end
+  end
+end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,0 +1,45 @@
+require_relative 'test_helper'
+require_relative '../plugins/' + File.basename(__FILE__, '_spec.rb')
+
+describe OrrInfoCommand do
+  before do
+    invocation_path = ""
+    @info = OrrListCommand.new(invocation_path)
+  end
+
+  describe "when executed" do
+    it "lists installed and active ruby versions" do
+      rpm_out = <<EOT
+libruby2_2-2_2-2.2.5-1.5.x86_64
+ruby2.2-rubygem-rack-protection-1.5.3-4.1.x86_64
+ruby2.2-2.2.5-1.5.x86_64
+ruby2.2-rubygem-rack-1.6.4-22.21.x86_64
+ruby2.1-2.1.9-1.1.x86_64
+ruby2.2-rubygem-rspec-support-3.5.0-1.1.x86_64
+ruby-devel-2.2-1.3.x86_64
+EOT
+
+      mock = Minitest::Mock.new
+      mock.expect :run, rpm_out, ["rpm -qa"]
+      mock.expect :run, "/path/to/ruby", ["which ruby"]
+      mock.expect :run, "ruby2.2-2.2.5-1.5.x86_64", ["rpm -qf /path/to/ruby"]
+      mock.expect :run, "ruby 2.2.5p319 (2016-04-26 revision 54774) [x86_64-linux-gnu]", ["ruby -v"]
+
+      expected_out = <<EOT
+Installed ruby versions:
+* ruby2.1
+* ruby2.2
+
+Active ruby:
+* ruby2.2 (path: /path/to/ruby, version: ruby 2.2.5p319 (2016-04-26 revision 54774) [x86_64-linux-gnu])
+EOT
+
+      @info.stub :shell_command, mock do
+        arguments = []
+        assert_output(expected_out) {
+          @info.run(arguments)
+        }
+      end
+    end
+  end
+end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -1,0 +1,43 @@
+require_relative 'test_helper'
+require_relative '../plugins/' + File.basename(__FILE__, '_spec.rb')
+
+describe OrrSearchCommand do
+  before do
+    invocation_path = ""
+    @search = OrrSearchCommand.new(invocation_path)
+  end
+
+  describe "when executed" do
+    it "returns available ruby versions" do
+    zypper_out = <<EOT
+<?xml version='1.0'?>
+<stream>
+<message type="info">Loading repository data...</message>
+<message type="info">Reading installed packages...</message>
+
+<search-result version="0.0">
+<solvable-list>
+<solvable status="installed" name="ruby" summary="An Interpreted Object-Oriented Scripting Language" kind="package"/>
+<solvable status="installed" name="ruby2.1" summary="An Interpreted Object-Oriented Scripting Language" kind="package"/>
+<solvable status="installed" name="ruby2.2" summary="An Interpreted Object-Oriented Scripting Language" kind="package"/>
+<solvable status="not-installed" name="ruby2.2" summary="An Interpreted Object-Oriented Scripting Language" kind="srcpackage"/>
+<solvable status="not-installed" name="ruby2.3" summary="An Interpreted Object-Oriented Scripting Language" kind="package"/>
+<solvable status="not-installed" name="ruby2.3" summary="An Interpreted Object-Oriented Scripting Language" kind="srcpackage"/>
+<solvable status="not-installed" name="ruby2.4-rubygem-ffi" summary="Ruby FFI" kind="package"/>
+<solvable status="not-installed" name="rubygem-yast-rake" summary="Rake tasks providing basic work-flow for Yast development" kind="srcpackage"/>
+</solvable-list>
+</search-result>
+</stream>
+EOT
+
+      mock = Minitest::Mock.new
+      mock.expect :run, zypper_out, ["zypper --xml se 'ruby*'"]
+      @search.stub :shell_command, mock do
+        arguments = []
+        assert_output("ruby2.1 (installed)\nruby2.2 (installed)\nruby2.3\n") do
+          @search.run(arguments)
+        end
+      end
+    end
+  end
+end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,3 +1,5 @@
 require "minitest/autorun"
-require "clamp"
+require "minitest/stub_const"
 require 'pry'
+
+require_relative "../lib/orr.rb"


### PR DESCRIPTION
This pull request adds basic implementations of the `info`, `search`, `list`, and `install` commands. It was tested on Tumbleweed.
