### PR TITLE
Introduces OrrConfig, a configuration class

### DIFF
--- a/lib/orr.rb
+++ b/lib/orr.rb
@@ -1,7 +1,8 @@
 require 'clamp'
 require 'rbconfig'
 require "rexml/document"
-require "pathname"
+require 'fileutils'
 
 require_relative 'shell_command'
 require_relative 'orr_command'
+require_relative 'orr_config'

--- a/lib/orr_config.rb
+++ b/lib/orr_config.rb
@@ -1,0 +1,51 @@
+module OrrConfig
+  HOME_DIR = ENV['HOME'] + '/'
+  ORR_DIR = HOME_DIR + '.orr/'
+  BIN_DIR = ORR_DIR + 'bin/'
+  PROFILE_FILE = HOME_DIR + '.orr_profile'
+  GEMRC_FILE = HOME_DIR + ".gemrc"
+  BASHRC_FILE = HOME_DIR + '.bashrc'
+  ORR_BINARIES = %w( ruby irb gem rake )
+
+  def orr_setup
+    # Create what we need on startup
+    [ORR_DIR, BIN_DIR].each do |directory|
+      Dir.mkdir(directory) unless Dir.exist?(directory)
+    end
+    edit_bashrc
+    edit_gemrc
+  end
+
+  private
+
+  # FIXME: /etc/profile.d is the place to do this in general, for all shells
+  def edit_bashrc
+    profile_setting = 'test -s ~/.orr_profile && . ~/.orr_profile || true'
+
+    found_profile_setting = false
+    if File.exist?(BASHRC_FILE)
+      BASHRC_FILE.each_line do |line|
+        found_profile_setting = true if line.chomp == profile_setting
+      end
+    end
+
+    File.open(BASHRC_FILE, 'a') do |f|
+      f.puts(profile_setting) unless found_profile_setting
+    end
+  end
+
+  def edit_gemrc
+    install_setting = "install: --no-format-executable"
+
+    found_install_setting = false
+    if File.exist?(GEMRC_FILE)
+      GEMRC_FILE.each_line do |line|
+        found_install_setting = true if line.chomp == install_setting
+      end
+    end
+
+    File.open(GEMRC_FILE, 'a') do |f|
+      f.puts(install_setting) unless found_install_setting
+    end
+  end
+end

--- a/orr
+++ b/orr
@@ -1,7 +1,14 @@
 #!/usr/bin/env ruby
 require_relative 'lib/orr'
-Dir[File.join(File.dirname(__FILE__), 'plugins', '*.rb')].each {|file| require file } 
 
+include OrrConfig
+# Setup what we need...
+orr_setup
+
+# Load all plugins
+Dir[File.join(File.dirname(__FILE__), 'plugins', '*.rb')].each {|file| require file }
+
+# Setup commands
 Clamp do
 
   option ["--version", "-v"], :flag, "Show version" do
@@ -12,7 +19,7 @@ Clamp do
   self.default_subcommand = "info"
 
   subcommand "info", "show information for current ruby", OrrInfoCommand
-  subcommand "search", "show available ruby versions", OrrSearchCommand 
+  subcommand "search", "show available ruby versions", OrrSearchCommand
   subcommand "use", "setup current shell to use a specific ruby version", OrrUseCommand
   subcommand "reset", "remove default and current settings, exit the shell", OrrResetCommand
   subcommand "list", "show currently installed versions", OrrListCommand

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -8,106 +8,58 @@ describe OrrInstallCommand do
   end
 
   describe "when ruby version is not installed yet" do
-    it "installs given ruby version" do
-      arguments = ["2.3"]
-      Dir.mktmpdir("orr-test") do |home_dir|
-        bin_dir = Pathname.new(home_dir) + "bin"
-        Dir.mkdir(bin_dir)
-
-        bashrc = Pathname.new(home_dir) + ".bashrc"
-        bashrc_content = <<EOT
-# This is an exemplary .bashrc
-PS1='something'
-EOT
-        File.write(bashrc, bashrc_content)
-
-        env = ENV.to_hash.merge("HOME" => home_dir)
-
-        mock = Minitest::Mock.new
-        mock.expect :run_interactive, nil, ["sudo zypper in ruby2.3"]
-
-        @cmd.stub :shell_command, mock do
-          assert_output(/^Installing ruby2.3 in #{bin_dir}\n/) do
-            Object.stub_const(:ENV, env) do
-              @cmd.run(arguments)
-            end
-          end
-        end
-        assert_equal("/usr/bin/ruby.ruby2.3", File.readlink(bin_dir + "ruby"))
-        assert_equal("/usr/bin/irb.ruby2.3", File.readlink(bin_dir + "irb"))
-        assert_equal("/usr/bin/gem.ruby2.3", File.readlink(bin_dir + "gem"))
-        assert_equal("/usr/bin/rake.ruby2.3", File.readlink(bin_dir + "rake"))
-
-        expected_bashrc_content = bashrc_content + <<EOT
+    before do
+      @expected_profile_content = <<EOT
 export GEM_HOME=~/.gems/ruby2.3
 export PATH=$GEM_HOME/bin:$PATH
 EOT
-        assert_equal(expected_bashrc_content, File.read(bashrc))
+    end
+    it "installs given ruby version" do
+      arguments = ["2.3"]
+      mock = Minitest::Mock.new
+      mock.expect :run_interactive, nil, ["sudo zypper in ruby2.3"]
 
-        expected_gemrc_content = <<EOT
-install: --no-format-executable
-EOT
-        assert_equal(expected_gemrc_content, File.read(Pathname.new(home_dir) + ".gemrc"))
+      @cmd.stub :shell_command, mock do
+        assert_output(/^Installing ruby2.3 in #{BIN_DIR}\n/) do
+          @cmd.run(arguments)
+        end
       end
+
+      ORR_BINARIES.each do |cmd|
+        assert_equal("/usr/bin/#{cmd}.ruby2.3", File.readlink(BIN_DIR + cmd))
+      end
+
+      assert_equal(@expected_profile_content, File.read(PROFILE_FILE))
     end
   end
 
   describe "when ruby version is already installed" do
-    it "installs given ruby version" do
-      arguments = ["2.3"]
-      Dir.mktmpdir("orr-test") do |home_dir|
-        bin_dir = Pathname.new(home_dir) + "bin"
-        Dir.mkdir(bin_dir)
-        ["ruby", "irb", "gem", "rake"].each do |cmd|
-          File.symlink("/usr/bin/#{cmd}.ruby2.2", bin_dir + cmd)
-        end
-
-        bashrc = Pathname.new(home_dir) + ".bashrc"
-        bashrc_content = <<EOT
-# This is an exemplary .bashrc
-PS1='something'
-export GEM_HOME=~/.gems/ruby2.2
-export PATH=$GEM_HOME/bin:$PATH
-# something else
-EOT
-        File.write(bashrc, bashrc_content)
-
-        gemrc_content = <<EOT
-install: --no-format-executable
-EOT
-        File.write(Pathname(home_dir) + ".gemrc", gemrc_content)
-
-        env = ENV.to_hash.merge("HOME" => home_dir)
-
-        mock = Minitest::Mock.new
-        mock.expect :run_interactive, nil, ["sudo zypper in ruby2.3"]
-
-        @cmd.stub :shell_command, mock do
-          assert_output(/^Installing ruby2.3 in #{bin_dir}\n/) do
-            Object.stub_const(:ENV, env) do
-              @cmd.run(arguments)
-            end
-          end
-        end
-        assert_equal("/usr/bin/ruby.ruby2.3", File.readlink(bin_dir + "ruby"))
-        assert_equal("/usr/bin/irb.ruby2.3", File.readlink(bin_dir + "irb"))
-        assert_equal("/usr/bin/gem.ruby2.3", File.readlink(bin_dir + "gem"))
-        assert_equal("/usr/bin/rake.ruby2.3", File.readlink(bin_dir + "rake"))
-
-        expected_bashrc_content = <<EOT
-# This is an exemplary .bashrc
-PS1='something'
-export GEM_HOME=~/.gems/ruby2.3
-export PATH=$GEM_HOME/bin:$PATH
-# something else
-EOT
-        assert_equal(expected_bashrc_content, File.read(bashrc))
-
-        expected_gemrc_content = <<EOT
-install: --no-format-executable
-EOT
-        assert_equal(expected_gemrc_content, File.read(Pathname.new(home_dir) + ".gemrc"))
+    before do
+      ORR_BINARIES.each do |cmd|
+        File.symlink("/usr/bin/#{cmd}.ruby2.2", BIN_DIR + cmd)
       end
+      @expected_profile_content = <<EOT
+export GEM_HOME=~/.gems/ruby2.4
+export PATH=$GEM_HOME/bin:$PATH
+EOT
+    end
+
+    it "installs given ruby version" do
+      arguments = ["2.4"]
+      mock = Minitest::Mock.new
+      mock.expect :run_interactive, nil, ["sudo zypper in ruby2.4"]
+
+      @cmd.stub :shell_command, mock do
+        assert_output(/^Installing ruby2.4 in #{BIN_DIR}\n/) do
+          @cmd.run(arguments)
+        end
+      end
+
+      ORR_BINARIES.each do |cmd|
+        assert_equal("/usr/bin/#{cmd}.ruby2.4", File.readlink(BIN_DIR + cmd))
+      end
+
+      assert_equal(@expected_profile_content, File.read(PROFILE_FILE))
     end
   end
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,5 +1,28 @@
+require 'tmpdir'
+# Do not pollute actual directories with our stuff...
+tempdir = Dir.mktmpdir("orr-test")
+ENV['HOME'] = tempdir
+
 require "minitest/autorun"
 require "minitest/stub_const"
 require 'pry'
-
 require_relative "../lib/orr.rb"
+
+include OrrConfig
+orr_setup
+
+class Minitest::Test
+  # After each test...
+  def teardown
+    # cleanup directories and files
+    FileUtils.cd(BIN_DIR) do
+       FileUtils.rm_f ORR_BINARIES
+    end
+    FileUtils.rm_f [GEMRC_FILE, BASHRC_FILE, PROFILE_FILE]
+  end
+end
+
+# Too new...
+#Minitest.after_run {
+#  FileUtils.remove_dir tempdir
+#}


### PR DESCRIPTION
* Setup things we need in the system. Directories and bashrc
* Hold path names to important files

This also moves the environment variables out of bashrc into our
own file, then we don't have to worry about exchanging lines but
can replace the whole file all the time.